### PR TITLE
Enhance test, fix coding style and static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,17 @@ matrix:
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 7.3
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - php: 7.4
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
           # Test the latest stable release
         - php: 7.2
         - php: 7.3
+        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover=coverage.xml"
 
           # Latest commit to master
-        - php: 7.3
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:

--- a/DependencyInjection/CompilerPass/AddLoaderToSerializerCacheWarmerPass.php
+++ b/DependencyInjection/CompilerPass/AddLoaderToSerializerCacheWarmerPass.php
@@ -20,7 +20,7 @@ final class AddLoaderToSerializerCacheWarmerPass implements CompilerPassInterfac
     {
         if (!$container->hasDefinition('serializer.mapping.cache_warmer')) {
             return;
-        };
+        }
 
         $definition = $container->getDefinition('serializer.mapping.cache_warmer');
         $argument = $definition->getArgument(0);

--- a/DependencyInjection/CompilerPass/AddLoaderToValidationBuilderPass.php
+++ b/DependencyInjection/CompilerPass/AddLoaderToValidationBuilderPass.php
@@ -18,7 +18,7 @@ final class AddLoaderToValidationBuilderPass implements CompilerPassInterface
     {
         if (!$container->hasDefinition('validator.builder')) {
             return;
-        };
+        }
 
         $validatorBuilder = $container->getDefinition('validator.builder');
         $validatorBuilder->addMethodCall('addLoader', [new Reference(FakeValidatorLoader::class)]);

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,15 @@
         }
     ],
     "require": {
+        "php": "^7.2",
         "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
-        "doctrine/annotations": "^1.6"
+        "symfony/console": "^3.4 || ^4.3 || ^5.0",
+        "symfony/serializer": "^3.4 || ^4.3 || ^5.0",
+        "symfony/validator": "^3.4 || ^4.3 || ^5.0",
+        "symfony/config": "^3.4 || ^4.3 || ^5.0",
+        "symfony/debug": "^3.4 || ^4.3 || ^5.0",
+        "doctrine/annotations": "^1.8",
+        "phpstan/phpstan": "^0.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,4 +8,10 @@ parameters:
 	ignoreErrors:
 		-
 			path: %currentWorkingDirectory%/DependencyInjection/Configuration.php
-			message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children()#'
+			message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root().#'
+		-
+			path: %currentWorkingDirectory%/Loader/FakeSerializerLoader.php
+			message: '#Method Happyr\\AnnotationWarmer\\Loader\\FakeSerializerLoader::loadClassMetadata().#'
+		-
+			path: %currentWorkingDirectory%/Loader/FakeValidatorLoader.php
+			message: '#Method Happyr\\AnnotationWarmer\\Loader\\FakeValidatorLoader::loadClassMetadata().#'


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version test during Travis CI build.
- Fix coding style via `PHP-CS-Fixer` on GitHub actions.
- Fix static analysis error via `PHPStan` on GitHub actions.
- Add some path and message to `ignoreErrors` block on `phpstan.neon.dist`.
It can pass some unnecessary error during static analysis error.
- Installing some suggested dependencies to avoid most of errors during PHPStan static analysis.
- According to this [issue](https://github.com/doctrine/annotations/issues/273), it should upgrade the `doctrine/annotations` version to `1.8` to fix this issue.